### PR TITLE
feat!: ensure that the contract struct always implements trait

### DIFF
--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{Address, Env, contract, contracttype};
 
 use admin_sep::{
-    Admin, Administratable, AdministratableExt, Constructable, HasAdmin, Upgradable,
+    Admin, Administratable, AdministratableExt, Constructable, HasAdmin, Upgradable, Upgrader,
     derive_contract,
 };
 

--- a/admin_sep/src/administratable.rs
+++ b/admin_sep/src/administratable.rs
@@ -1,7 +1,6 @@
 use contract_trait_macro::contracttrait;
 use soroban_sdk::{Address, Env, Symbol, symbol_short};
 
-
 /// Trait for using an admin address to control access.
 #[contracttrait(default = Admin, is_extension = true)]
 pub trait Administratable {

--- a/admin_sep/src/constructor.rs
+++ b/admin_sep/src/constructor.rs
@@ -73,4 +73,6 @@ impl_has_admin_for_tuples!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);
 impl_has_admin_for_tuples!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);
 impl_has_admin_for_tuples!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);
 impl_has_admin_for_tuples!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);
-impl_has_admin_for_tuples!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);
+impl_has_admin_for_tuples!(
+    T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15
+);

--- a/admin_sep/src/upgradable.rs
+++ b/admin_sep/src/upgradable.rs
@@ -2,14 +2,23 @@ use contract_trait_macro::contracttrait;
 
 use crate::administratable::{Administratable, AdministratableExt};
 
-#[contracttrait(extension_required = true)]
+#[contracttrait(default = Upgrader, extension_required = true)]
 pub trait Upgradable {
+    fn upgrade(env: &soroban_sdk::Env, wasm_hash: soroban_sdk::BytesN<32>);
+}
+
+pub struct Upgrader;
+
+impl Upgradable for Upgrader {
+    type Impl = Upgrader;
     fn upgrade(env: &soroban_sdk::Env, wasm_hash: soroban_sdk::BytesN<32>) {
         env.deployer().update_current_contract_wasm(wasm_hash);
     }
 }
 
+
 impl<T: Administratable, N: Upgradable> Upgradable for AdministratableExt<T, N> {
+    type Impl = N;
     fn upgrade(env: &soroban_sdk::Env, wasm_hash: soroban_sdk::BytesN<32>) {
         T::admin(env).require_auth();
         N::upgrade(env, wasm_hash);

--- a/admin_sep/src/upgradable.rs
+++ b/admin_sep/src/upgradable.rs
@@ -16,7 +16,6 @@ impl Upgradable for Upgrader {
     }
 }
 
-
 impl<T: Administratable, N: Upgradable> Upgradable for AdministratableExt<T, N> {
     type Impl = N;
     fn upgrade(env: &soroban_sdk::Env, wasm_hash: soroban_sdk::BytesN<32>) {

--- a/contract-trait-macro/src/contracttrait.rs
+++ b/contract-trait-macro/src/contracttrait.rs
@@ -364,10 +364,10 @@ mod tests {
         );
         println!("{}", format_snippet(&result.to_string()));
         let output = quote! {
-pub struct Contract;
-Upgradable ! (Contract , AdministratableExt < Contract , Upgradable ! () >);
-Administratable!(Contract, Administratable!());
-};
+        pub struct Contract;
+        Upgradable ! (Contract , AdministratableExt < Contract , Upgradable ! () >);
+        Administratable!(Contract, Administratable!());
+        };
         equal_tokens(&output, &result);
     }
 }

--- a/contract-trait-macro/src/error.rs
+++ b/contract-trait-macro/src/error.rs
@@ -6,7 +6,6 @@ pub enum Error {
     Stream(TokenStream),
     #[error(transparent)]
     Syn(#[from] syn::Error),
-
 }
 
 impl From<Error> for TokenStream {

--- a/contract-trait-macro/src/lib.rs
+++ b/contract-trait-macro/src/lib.rs
@@ -35,5 +35,3 @@ pub fn derive_contract(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     contracttrait::derive_contract(&parsed_args, &parsed).into()
 }
-
-

--- a/contract-trait-macro/src/util.rs
+++ b/contract-trait-macro/src/util.rs
@@ -14,7 +14,6 @@ pub(crate) fn p_e(e: std::io::Error) -> std::io::Error {
     e
 }
 
-
 /// Format the given snippet. The snippet is expected to be *complete* code.
 /// When we cannot parse the given snippet, this function returns `None`.
 #[allow(unused)]

--- a/contract-trait-macro/src/util.rs
+++ b/contract-trait-macro/src/util.rs
@@ -34,6 +34,5 @@ pub(crate) fn format_snippet(snippet: &str) -> String {
     child.wait().unwrap();
     let mut buf = String::new();
     child.stdout.unwrap().read_to_string(&mut buf).unwrap();
-    println!("\n\n\n{buf}\n\n\n");
     buf
 }


### PR DESCRIPTION
Now all traits must have an `type Impl` and ensure that the default implementation is present or provided. Also ensures that extensions always end with the default implementation.

This way the external contract methods call `<Contract as Administratable>::admin(env)`. Then the contract implements the trait as

```rust
impl Administratable as Contract {
    type Impl = Admin;
}
```
And extensions as:
```rust
impl Upgrandable as Contract {
    type Impl = AdminstratableExt<Contract, Upgrader>
}
```

This ensures that the path for an extension always starts the with contract. And `derive` always implies that the type will implement the supplied trait.